### PR TITLE
Tijdelijk weer teruggezet op atlas.amsterdam.nl. Tot livegang. 

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -97,7 +97,7 @@
 </head>
 <body>
     <div class="header">
-        <a href="https://data.amsterdam.nl/" title="Naar voorpagina Dataportaal">
+        <a href="https://atlas.amsterdam.nl/" title="Naar voorpagina Dataportaal">
             <img class="header_logo" src="logo-short.svg" width="64" height="30">
             <span class="header_title">AmsterdamData</span>
         </a>


### PR DESCRIPTION
Daarna moet het weer data.amsterdam.nl worden.